### PR TITLE
Replace yarn by npx when create expo app

### DIFF
--- a/script.js
+++ b/script.js
@@ -187,7 +187,7 @@ async function initializeExpo(answers) {
   group(
     'Initialize project',
     () => {
-      command(`yarn create expo-app ${answers.projectName} -t blank`);
+      command(`npx create-expo-app ${answers.projectName} -t blank`);
       cd(answers.projectName);
     },
     {commit: false}


### PR DESCRIPTION
There is a documentation problem in the expo. On the official link, it says that to use, just any latest TLS version (and it works, when using npx). However, when using yarn and installed via global, expo-cli requires version >= 12 <= 16 (which doesn't make any sense to me). Reading the issues, for some they do since the same (expo) was not tested in more recent versions of the node.

This PR puts npx aiming to ignore this issue.